### PR TITLE
[#8] feat: Add RandomMusicRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ Temporary Items
 
 # vim
 *.swp
+
+Secret.xcconfig

--- a/LiarGame/Resources/Info.plist
+++ b/LiarGame/Resources/Info.plist
@@ -23,5 +23,7 @@
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>ㅠ</string>
+	<key>GOOGLE_APIKEY</key>
+	<string>$(GOOGLE_APIKEY)</string>
 </dict>
 </plist>

--- a/LiarGame/Sources/Model/Music.swift
+++ b/LiarGame/Sources/Model/Music.swift
@@ -1,0 +1,38 @@
+//
+//  Music.swift
+//  LiarGame
+//
+//  Created by JK on 2022/04/22.
+//
+
+import Foundation
+
+struct Music: Codable {
+  let title: String
+  let artist: String
+  /// youtube video ID
+  let id: String
+  let startedAt: String
+  
+  /** Music 생성자
+   
+   들어오는 배열의 구조:
+   [title, artist,id, startedAt]
+   
+   - title: 노래 제목
+   - artist: 가수
+   - id: 유튜브 동영상 id
+   - startedAt: 첫 재생 시각
+   
+   길이가 맞지 않을 경우 `return nil`
+  */
+  init?(from array: [String]) {
+    guard array.count == 4 else { return nil }
+    
+    self.title = array[0]
+    self.artist = array[1]
+    self.id = array[2]
+    self.startedAt = array[3]
+  }
+}
+

--- a/LiarGame/Sources/Model/MusicSheetDTO.swift
+++ b/LiarGame/Sources/Model/MusicSheetDTO.swift
@@ -1,0 +1,18 @@
+//
+//  MusicSheetDTO.swift
+//  LiarGame
+//
+//  Created by JK on 2022/04/22.
+//
+
+import Foundation
+
+// MARK: - MusicSheetDTO
+struct MusicSheetDTO: Decodable {
+    let range, majorDimension: String
+    let values: [[String]]
+}
+
+
+
+

--- a/LiarGame/Sources/Repository/RandomMusicRepository.swift
+++ b/LiarGame/Sources/Repository/RandomMusicRepository.swift
@@ -1,0 +1,169 @@
+//
+//  RandomMusicRepository.swift
+//  LiarGame
+//
+//  Created by JK on 2022/04/22.
+//
+
+import Foundation
+import RxSwift
+
+protocol RandomMusicRepositoryType {
+  /// 최신 버전을 확인합니다.
+  var newestVersion: Single<String> { get }
+  /// 현재 저장되어 있는 버전을 확인합니다.
+  var currentVersion: String { get }
+  /// 버전 업데이트를 수행합니다.
+  func getNewestVersion() -> Single<[Music]>
+  /// 저장되어있는 음악 리스트를 가져옵니다.
+  var musicList: [Music] { get }
+}
+
+
+final class RandomMusicRepository: RandomMusicRepositoryType {
+  
+  /// 리스트를 담고 있는 Google Sheet ID
+  private var sheetID: String = "1jiAcDhKOoMbfLmlCOba33CMAZCwlpaV3enkLVvjMmIA"
+  private var googleAPIKey: String {
+    (Bundle.main.object(forInfoDictionaryKey: "GOOGLE_APIKEY") as? String) ?? ""
+  }
+  
+  /// 현재 저장되어 있는 버전
+  var currentVersion: String {
+    Self._currentVersion
+  }
+  
+  @UserDefault(key: "RandomMusicVersion", defaultValue: "")
+  private static var _currentVersion: String
+  
+  /** 저장되어있는 음악 목록을 가져옵니다.
+   
+   최신 버전을 보증하지 않음.
+   */
+  var musicList: [Music] {
+    do {
+      return try readMuicList()
+    } catch {
+      return []
+    }
+  }
+  
+  var newestVersion: Single<String> {
+    _newsetVersion
+      .map { $0.components(separatedBy: ",")[0] }
+  }
+  
+  func setCurrent(version: String) {
+    Self._currentVersion = version
+  }
+  
+  /// 버전 확인 후 최신 버전을 가져옵니다.
+  func getNewestVersion() -> Single<[Music]> {
+    _newsetVersion
+      .flatMap { _version -> Single<[Music]> in
+        let arr = _version.components(separatedBy: ",")
+        let version = arr[0]
+        let length = arr[1]
+        guard version != self.currentVersion else { return .just(try self.readMuicList()) }
+        
+        return self.update(version: version, length: length)
+      }
+  }
+  
+  /// 최신 목록으로 업데이트를 수행합니다.
+  private func update(version: String, length: String) -> Single<[Music]> {
+    guard let url = URL(string: "https://sheets.googleapis.com/v4/spreadsheets/\(self.sheetID)/values/Sheet!A2:D\(length)?key=\(self.googleAPIKey)") else {
+      assertionFailure("URL String error")
+      return .error(RandomMusicRepositoryError.castingError)
+    }
+    
+    return URLSession.shared.rx.response(request: URLRequest(url: url))
+      .map { (response, data) -> Data in
+        guard 200..<300 ~= response.statusCode else {
+          throw RandomMusicRepositoryError.requestFailed
+        }
+        
+        return data
+      }
+      .asSingle()
+    // 타입 변환
+      .map { data -> MusicSheetDTO in
+        do {
+          return try JSONDecoder().decode(MusicSheetDTO.self, from: data)
+        } catch {
+          throw RandomMusicRepositoryError.parseError
+        }
+      }
+      .map(\.values)
+      .map { $0.compactMap(Music.init) }
+    // 저장
+      .do(onSuccess: { musicList in
+        self.setCurrent(version: version)
+        try self.writeMusicList(from: musicList)
+      })
+  }
+
+  /** 최신 정보를 받아옵니다.
+   
+   return 값인 String 의 구조는 다음과 같습니다.
+   
+   [업데이트된버전],[시트의 마지막행]
+   
+   ex) 20220422,5
+   */
+  private var _newsetVersion: Single<String> {
+    guard let url = URL(string: "https://dl.dropboxusercontent.com/s/g55fwxp70a16xl1/version.txt") else {
+      assertionFailure("URL String error")
+      return .error(RandomMusicRepositoryError.castingError)
+    }
+    let request = URLRequest(url: url)
+    return URLSession.shared.rx.data(request: request)
+      .map {
+        guard let str = String(data: $0, encoding: .utf8) else {
+          throw RandomMusicRepositoryError.requestFailed
+        }
+        
+        return str
+      }
+      .asSingle()
+  }
+  
+  /// 음악 데이터 저장
+  private func writeMusicList(from musicList: [Music]) throws {
+    if musicList.isEmpty { fatalError() }
+    let path = try musicDataPath()
+    do {
+      let data = try JSONEncoder().encode(musicList)
+      try data.write(to: path, options: .atomic)
+    } catch {
+      throw RandomMusicRepositoryError.fileWriteFailed
+    }
+  }
+  
+  /// 음악 데이터 읽어오기
+  // TODO: - private 으로 변경///
+  func readMuicList() throws -> [Music] {
+    let path = try musicDataPath()
+    let data = try Data(contentsOf: path)
+    
+    return try JSONDecoder().decode([Music].self, from: data)
+  }
+  
+  /// 음악 데이터를 저장하는 경로
+  // TODO: - private 으로 변경/// 
+  func musicDataPath() throws -> URL {
+    guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+      throw RandomMusicRepositoryError.fileAccessFailed
+    }
+    
+    return documentsURL.appendingPathComponent("MusicListData.bin")
+  }
+}
+
+enum RandomMusicRepositoryError: Error {
+  case requestFailed
+  case castingError
+  case parseError
+  case fileAccessFailed
+  case fileWriteFailed
+}

--- a/LiarGame/Sources/Utils/Userdefaults+PropertyWrapper.swift
+++ b/LiarGame/Sources/Utils/Userdefaults+PropertyWrapper.swift
@@ -1,0 +1,24 @@
+//
+//  Userdefaults+PropertyWrapper.swift
+//  LiarGame
+//
+//  Created by JK on 2022/04/22.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefault<Value> {
+    let key: String
+    let defaultValue: Value
+    var container: UserDefaults = .standard
+
+    var wrappedValue: Value {
+        get {
+            return container.object(forKey: key) as? Value ?? defaultValue
+        }
+        set {
+            container.set(newValue, forKey: key)
+        }
+    }
+}

--- a/xcconfig/LiarGame-Shared.xcconfig
+++ b/xcconfig/LiarGame-Shared.xcconfig
@@ -180,3 +180,5 @@ SWIFT_VERSION = 5.0
 // compilation.
 
 TARGETED_DEVICE_FAMILY = 1,2
+ 
+#include "Secret.xcconfig"


### PR DESCRIPTION
#8

## 배경

랜덤 음악 목록을 가져오는 기능 추가.

## 목적


랜덤한 음악을 가져올 [시트](https://docs.google.com/spreadsheets/d/1jiAcDhKOoMbfLmlCOba33CMAZCwlpaV3enkLVvjMmIA/edit#gid=0) 추가. 
버전 관리를 위한 dropbox [file](https://dl.dropboxusercontent.com/s/g55fwxp70a16xl1/version.txt) 추가

시트에서 데이터를 가져오는 기능 추가하였습니다.

## 리뷰 시 참고사항

API 키 저장을 위한 `Secret.xcconfig` 파일을 추가하였습니다.  (해당 파일은 git으로 관리되지 않습니다.)
해당 파일은 `xcconfig/` 내부에 보관됩니다.

이로 인해 `Info.plist` 파일에 수정이 있어 먼저 pr 보냅니다.

