### PR TITLE
RandomMusicQuiz 무한로딩, 업데이트 오류 수정

### DIFF
--- a/LiarGame/Sources/Reactor/RandomMusicQuizReactor.swift
+++ b/LiarGame/Sources/Reactor/RandomMusicQuizReactor.swift
@@ -80,8 +80,8 @@ final class RandomMusicQuizReactor: Reactor {
         repository.getNewestVersion()
           .asObservable()
           .map { _ in Mutation.ignore },
-        .just(.updateCurrentMusic(shuffleMusic())),
         .just(.updateCurrentVersion(repository.currentVersion)),
+        shuffleMusic()
       ])
       .timeout(.seconds(10), other: Observable.just(Mutation.updateLoading(false)), scheduler: scheduler)
 
@@ -104,7 +104,7 @@ final class RandomMusicQuizReactor: Reactor {
         .just(.updateLoading(true)),
         .just(.updatePlayStopState(false)),
         .just(.updateAnswer(nil)),
-        .just(.updateCurrentMusic(shuffleMusic()))
+        shuffleMusic()
       )
 
     case .needCurrentVersion:
@@ -141,12 +141,16 @@ final class RandomMusicQuizReactor: Reactor {
     }
   }
 
-  private func shuffleMusic() -> Music? {
-    guard repository.musicList.count > 0 else { return nil }
+  private func shuffleMusic() -> Observable<Mutation> {
+    guard repository.musicList.count > 0 else {
+      self.playerState = .unknwon
+      return .just(.updateLoading(false))
+    }
+    
     let size = repository.musicList.count
     let randomNumber = Int(arc4random()) % size
 
-    return repository.musicList[randomNumber]
+    return .just(.updateCurrentMusic(repository.musicList[randomNumber]))
   }
 
   // `YTPlayerView.playVideo()` 호출 시점과 실제 재생 시점이 다름

--- a/LiarGame/Sources/ViewController/RandomMusicQuiz/RandomMusicQuizViewController.swift
+++ b/LiarGame/Sources/ViewController/RandomMusicQuiz/RandomMusicQuizViewController.swift
@@ -127,6 +127,7 @@ final class RandomMusicQuizViewController: UIViewController, View {
 
     reactor.state.map(\.isLoading)
       .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
       .subscribe(onNext: content.setLoading(_:))
       .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 배경

1. 첫 실행 시 로딩 인디케이터가 멈추지 않은 문제 

2. 음악 목록 업데이트 시 데이터가 바로 반영되지 않는 문제 

## 작업내용


1. 저장되어 있는 음악이 없을 때에도 음악이 로드를 대기하였고 로딩이 멈추지 않았음.
저장된 음악이 없을 때에는 로딩하지 않도록 수정


2. 이전에는 버전과 음악목록을 저장한 후 저장된 데이터를 읽어왔음. 이 결과 두 데이터 모두 즉시 업데이트 되지 않았음.
 디스크 I/O 동작의 경우 비동기적으로 이루어질 수 있고, `UserDefaults` 의 경우 비동기적으로 저장한다고 명시되어 있음.
 `Data.write` 의 경우도 백그라운드에서 사용을 권고하는 내용은 없는 것으로 미루어 보아 비동기적으로 동작할 것으로 추측함.
네트워크 요청을 통해 받아온 버전/음악 목록으로 바로 업데이트 수행하는 것으로 변경
