### PR TITLE
swiftformat sortDeclarations 주석처리

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -49,7 +49,7 @@
 --rules redundantFileprivate
 --rules redundantRawValues
 --rules sortedImports
---rules sortDeclarations
+# --rules sortDeclarations
 --rules strongifiedSelf
 --rules trailingCommas
 --rules trailingSpace


### PR DESCRIPTION
## 배경
main 브렌치에 해당 내용 때문에 빌드가 안되고 있습니다.

## 작업내용
임시로 주석처리했고 
https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md
봤을 땐 중요하지 않은 것 같아서 삭제해도 무방할 것 같습니다.