### PR TITLE
fix: Fix LiarGameSubjectVC Naming error

### DIFF
--- a/LiarGame/Sources/ViewController/LiarGame/LiarGameSubjectViewController.swift
+++ b/LiarGame/Sources/ViewController/LiarGame/LiarGameSubjectViewController.swift
@@ -36,7 +36,7 @@ final class LiarGameSubjectViewController: UIViewController, View {
   // MARK: View Lifecycle
   override func viewDidLoad() {
     view.backgroundColor = .background
-    setupView()
+    setLayout()
   }
 
   // MARK: Layout


### PR DESCRIPTION
함수 이름 수정

## 배경

#24 에서 Merge Conflict 를 수정하는 도중 과거에 사용했던 함수의 이름을 사용함
존재 하지 않는 함수 호출로 에러 발생

## 작업내용

함수 이름 변경
