### PR TITLE
chore: Comment unused swiftformat option

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -19,9 +19,9 @@
 --funcattributes prev-line # wrapAttributes
 --typeattributes prev-line # wrapAttributes
 --wrapternary before-operators # wrap
---structthreshold 20 # organizeDeclarations
---enumthreshold 20 # organizeDeclarations
---organizetypes class,struct,enum,extension # organizeDeclarations
+# --structthreshold 20 # organizeDeclarations
+# --enumthreshold 20 # organizeDeclarations
+# --organizetypes class,struct,enum,extension # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType

--- a/Project.yml
+++ b/Project.yml
@@ -6,14 +6,15 @@ configFiles:
   Debug: xcconfig/Project-Debug.xcconfig
   Release: xcconfig/Project-Release.xcconfig
 
-options: 
-  indentWidth: 2  
-  tabWidth: 2  
+options:
+  indentWidth: 2
+  tabWidth: 2
 
 packages:
   Then:
     url: https://github.com/devxoul/Then
-    version: 2.7.0
+    # version: 2.7.0
+    revision: d41ef523faef0f911369f79c0b96815d9dbb6d7a
   RxSwift:
     url: https://github.com/ReactiveX/RxSwift
     version: 6.5.0


### PR DESCRIPTION
## 배경

빌드시 발생하는 warning 을 쌓아두면 중요한 경고를 놓칠 수 있음. 

## 작업내용

- 사용하지 않는 swiftformat 옵션을 제거하였음.
- Dependency 중 `Then` 의 revision 이  'IPHONEOS_DEPLOYMENT_TARGET' 으로 해결된 버전으로 수정

